### PR TITLE
README: update URL from hashcat/oclhashcat to hashcat/hashcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AxSuite
 AxSuite is a toolset aimed to retrieve in-memory secrets saved by AxCrypt (http://www.axantum.com/axcrypt/)
 These secrets are sufficient enough to decrypt archives protected with AxCrypt, but you can also check
 my implementation of the algorithm within John The Ripper bleeding-jumbo (https://github.com/magnumripper/JohnTheRipper)
-and hashcat (https://github.com/hashcat/oclHashcat if you really need to retrieve the associated password.
+and hashcat (https://github.com/hashcat/hashcat) if you really need to retrieve the associated password.
 
 
 Author


### PR DESCRIPTION
The URL was outdated, we only have `hashcat` nowadays (no more cudaHashcat vs oclHashcat):
https://github.com/hashcat/hashcat

Thx